### PR TITLE
Add Payment domain entity with unit test

### DIFF
--- a/Domain.sln
+++ b/Domain.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "domain/Domain.csproj", "{B21B8E94-1FC0-4FA4-B404-8F6F306D4F3E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain.Tests", "tests/Domain.Tests.csproj", "{7C28F9E0-6E1B-4FE2-BDBC-8BD53EA401B3}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {B21B8E94-1FC0-4FA4-B404-8F6F306D4F3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B21B8E94-1FC0-4FA4-B404-8F6F306D4F3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B21B8E94-1FC0-4FA4-B404-8F6F306D4F3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {B21B8E94-1FC0-4FA4-B404-8F6F306D4F3E}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7C28F9E0-6E1B-4FE2-BDBC-8BD53EA401B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7C28F9E0-6E1B-4FE2-BDBC-8BD53EA401B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7C28F9E0-6E1B-4FE2-BDBC-8BD53EA401B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7C28F9E0-6E1B-4FE2-BDBC-8BD53EA401B3}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/domain/Domain.csproj
+++ b/domain/Domain.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/domain/Payment.cs
+++ b/domain/Payment.cs
@@ -1,0 +1,15 @@
+namespace Domain;
+
+public class Payment
+{
+    public Guid Id { get; private set; }
+    public decimal Amount { get; private set; }
+    public DateTime Date { get; private set; }
+
+    public Payment(decimal amount, DateTime date)
+    {
+        Id = Guid.NewGuid();
+        Amount = amount;
+        Date = date;
+    }
+}

--- a/tests/Domain.Tests.csproj
+++ b/tests/Domain.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\domain\Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/PaymentTest.cs
+++ b/tests/PaymentTest.cs
@@ -1,0 +1,18 @@
+using Domain;
+using Xunit;
+
+namespace Domain.Tests;
+
+public class PaymentTest
+{
+    [Fact]
+    public void TestPaymentEntityIsConsistent()
+    {
+        var date = new DateTime(2023, 12, 31);
+        var payment = new Payment(100m, date);
+
+        Assert.NotEqual(Guid.Empty, payment.Id);
+        Assert.Equal(100m, payment.Amount);
+        Assert.Equal(date, payment.Date);
+    }
+}


### PR DESCRIPTION
## Summary
- set up a minimal Domain project with a `Payment` entity
- add xUnit project with `PaymentTest` verifying the entity
- include a solution file for convenience

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684052ba3d888324865dce25ba7c681a