### PR TITLE
Implement CreatePayment use case

### DIFF
--- a/code/Application/src/Application/Application.csproj
+++ b/code/Application/src/Application/Application.csproj
@@ -4,6 +4,10 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-    </PropertyGroup>
+</PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Domain\src\Domain.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/code/Application/src/Application/Application.csproj
+++ b/code/Application/src/Application/Application.csproj
@@ -7,7 +7,7 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Domain\src\Domain.csproj" />
+    <ProjectReference Include="..\..\..\Domain\src\Domain.csproj" />
   </ItemGroup>
 
 </Project>

--- a/code/Application/src/Application/Dto/CreatePaymentInput.cs
+++ b/code/Application/src/Application/Dto/CreatePaymentInput.cs
@@ -1,0 +1,3 @@
+namespace Application.Dto;
+
+public readonly record struct CreatePaymentInput(int AmountValue, int Exponent, string Currency);

--- a/code/Application/src/Application/Repository/IPaymentRepository.cs
+++ b/code/Application/src/Application/Repository/IPaymentRepository.cs
@@ -4,5 +4,5 @@ using Domain.Entity;
 
 public interface IPaymentRepository
 {
-    void Save(Payment payment);
+    bool Save(Payment payment);
 }

--- a/code/Application/src/Application/Repository/IPaymentRepository.cs
+++ b/code/Application/src/Application/Repository/IPaymentRepository.cs
@@ -1,0 +1,8 @@
+namespace Application.Repository;
+
+using Domain.Entity;
+
+public interface IPaymentRepository
+{
+    void Save(Payment payment);
+}

--- a/code/Application/src/Application/UseCase/CreatePaymentUseCase.cs
+++ b/code/Application/src/Application/UseCase/CreatePaymentUseCase.cs
@@ -1,20 +1,13 @@
+using Application.Dto;
+
 namespace Application.UseCase;
 
-using Application.Repository;
+using Repository;
 using Domain.Entity;
 using Domain.ValueObject;
 
-public readonly record struct CreatePaymentInput(int AmountValue, int Exponent, string Currency);
-
-public class CreatePaymentUseCase
+public class CreatePaymentUseCase(IPaymentRepository repository)
 {
-    private readonly IPaymentRepository _repository;
-
-    public CreatePaymentUseCase(IPaymentRepository repository)
-    {
-        _repository = repository;
-    }
-
     public string Execute(CreatePaymentInput input)
     {
         var amount = new Amount(input.AmountValue, input.Exponent);
@@ -22,7 +15,7 @@ public class CreatePaymentUseCase
         var money = new Money(amount, currency);
         var payment = new Payment(Guid.NewGuid().ToString(), money);
 
-        _repository.Save(payment);
+        repository.Save(payment);
         return "OK";
     }
 }

--- a/code/Application/src/Application/UseCase/CreatePaymentUseCase.cs
+++ b/code/Application/src/Application/UseCase/CreatePaymentUseCase.cs
@@ -1,6 +1,28 @@
 namespace Application.UseCase;
 
+using Application.Repository;
+using Domain.Entity;
+using Domain.ValueObject;
+
+public readonly record struct CreatePaymentInput(int AmountValue, int Exponent, string Currency);
+
 public class CreatePaymentUseCase
 {
-    
+    private readonly IPaymentRepository _repository;
+
+    public CreatePaymentUseCase(IPaymentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public string Execute(CreatePaymentInput input)
+    {
+        var amount = new Amount(input.AmountValue, input.Exponent);
+        var currency = new Currency(input.Currency);
+        var money = new Money(amount, currency);
+        var payment = new Payment(Guid.NewGuid().ToString(), money);
+
+        _repository.Save(payment);
+        return "OK";
+    }
 }

--- a/code/Application/test/Application.Test/Application.Test.csproj
+++ b/code/Application/test/Application.Test/Application.Test.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+      <PackageReference Include="NSubstitute" Version="5.3.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
         <PrivateAssets>all</PrivateAssets>

--- a/code/Application/test/Application.Test/Class1.cs
+++ b/code/Application/test/Application.Test/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace Application.Test;
-
-public class Class1
-{
-}

--- a/code/Application/test/Application.Test/UseCase/CreatePaymentUseCaseTest.cs
+++ b/code/Application/test/Application.Test/UseCase/CreatePaymentUseCaseTest.cs
@@ -1,13 +1,52 @@
 using Application.UseCase;
+using Application.Repository;
+using Domain.Entity;
 using Xunit;
 
 namespace Application.Test.UseCase;
 
 public class CreatePaymentUseCaseTest
 {
-    [Fact]
-    public void ShouldTrue()
+    private class FakePaymentRepository : IPaymentRepository
     {
-        Assert.True(true);
+        private readonly Exception? _exception;
+        public bool SaveCalled { get; private set; }
+
+        public FakePaymentRepository(Exception? exception = null)
+        {
+            _exception = exception;
+        }
+
+        public void Save(Payment payment)
+        {
+            SaveCalled = true;
+            if (_exception is not null)
+            {
+                throw _exception;
+            }
+        }
+    }
+
+    [Fact]
+    public void Execute_ShouldReturnOk_WhenSaveSucceeds()
+    {
+        var repository = new FakePaymentRepository();
+        var useCase = new CreatePaymentUseCase(repository);
+        var input = new CreatePaymentInput(10, 2, "USD");
+
+        var result = useCase.Execute(input);
+
+        Assert.Equal("OK", result);
+        Assert.True(repository.SaveCalled);
+    }
+
+    [Fact]
+    public void Execute_ShouldThrow_WhenRepositoryFails()
+    {
+        var repository = new FakePaymentRepository(new InvalidOperationException());
+        var useCase = new CreatePaymentUseCase(repository);
+        var input = new CreatePaymentInput(10, 2, "USD");
+
+        Assert.Throws<InvalidOperationException>(() => useCase.Execute(input));
     }
 }

--- a/code/Domain/test/Domain.Test.csproj
+++ b/code/Domain/test/Domain.Test.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- add repository interface for payments
- implement CreatePaymentUseCase with input DTO
- reference Domain project from Application
- add unit tests for the use case

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684082b80c148324b468e88b9343e34c